### PR TITLE
use a textnode when rendering simple values

### DIFF
--- a/hyperhtml.js
+++ b/hyperhtml.js
@@ -200,9 +200,14 @@ var hyperHTML = (function () {'use strict';
     return function any(value) {
       var i, parentNode = node.parentNode;
       switch (typeof value) {
-        case 'string':
         case 'number':
         case 'boolean':
+          removeNodeList(childNodes, 0);
+          var newNode = document.createTextNode(value);
+          childNodes = [newNode];
+          parentNode.insertBefore(newNode, node);
+          break;
+        case 'string':
           removeNodeList(childNodes, 0);
           injectHTML(fragment, value);
           childNodes = slice.call(fragment.childNodes);


### PR DESCRIPTION
When `value` is a simple value (number or boolean) is straightforward to create a text node.

Before this PR, `injectHTML` was being called for that case. This function creates a fragment and updates its `innerHTML` property to finally extract the child nodes, but when value is a number or a boolean it cannot be more than one single text node, so I don't see any reason for calling `injectHTML`.  (I think this is valid also when value is a string but it does not contain `<` or `>`)

Please correct me if I'm wrong, I'm just a noob exploring the code.

