### PR TITLE
Update to preserve firstChild in list where incomming node is the same

### DIFF
--- a/hyperhtml.js
+++ b/hyperhtml.js
@@ -318,7 +318,11 @@ var hyperHTML = (function () {'use strict';
       case 1:
         var childNodes = parent.childNodes;
         if (childNodes.length !== 1 || childNodes[0] !== child) {
-          resetAndPopulate(parent, child);
+          if (childNodes[0] === child) {
+            removeNodeList(childNodes, 1);
+          } else {
+            resetAndPopulate(parent, child);
+          }
         }
         break;
       case 11:

--- a/test/test.js
+++ b/test/test.js
@@ -169,6 +169,70 @@ tressa.async(function (done) {
   });
 })
 .then(function () {
+  return tressa.async(function (done) {
+    tressa.log('## preserve first child where first child is the same as incoming');
+    var div = document.body.appendChild(document.createElement('div'));
+    var render = hyperHTML.bind(div);
+    var observer = new MutationObserver(function (mutations) {
+      for (var i = 0, len = mutations.length; i < len; i++) {
+        trackMutations(mutations[i].addedNodes, 'added')
+        trackMutations(mutations[i].removedNodes, 'removed')
+      }
+    });
+
+    observer.observe(div, {
+      childList: true,
+      subtree: true,
+    });
+
+    var counters = [];
+
+    function trackMutations (nodes, countKey) {
+      for (var i = 0, len = nodes.length, counter, key; i < len; i++) {
+        if (nodes[i] && nodes[i].getAttribute && nodes[i].getAttribute('data-test')) {
+          key = nodes[i].getAttribute('data-test')
+          counter = counters[key] || (counters[key] = { added: 0, removed: 0 });
+          counter[countKey]++;
+        }
+        if (nodes[i].childNodes.length > 0) {
+          trackMutations(nodes[i].childNodes, countKey);
+        }
+      }
+    }
+
+    var list = {};
+    var listItems = [];
+
+    function update(items) {
+      return hyperHTML.wire(list)`
+      <section>
+        <ul>${
+          items.map(function (item, i) {
+            return hyperHTML.wire((listItems[i] || (listItems[i] = {})))`
+            <li data-test="${i}">${item.text}</li>
+            `
+          })
+        }</ul>
+      </section>`;
+    }
+
+    setTimeout(function () {
+      render`${update([{ text: 'test1' }])}`;
+    });
+    setTimeout(function () {
+      render`${update([{ text: 'test1' }, { text: 'test2' }])}`;
+    });
+    setTimeout(function () {
+      render`${update([{ text: 'test1' }])}`;
+    });
+    setTimeout(function () {
+      tressa.assert(counters[0].added === 1, 'first item added only once');
+      tressa.assert(counters[0].removed === 0, 'first item never removed');
+      done();
+    });
+  });
+})
+.then(function () {
   if (!tressa.exitCode) {
     document.body.style.backgroundColor = '#0FA';
   }


### PR DESCRIPTION
Unfortunately the tests aren't exactly working - potentially due to lack of `MutationObserver` in `jsdom` https://github.com/tmpvar/jsdom/issues/639 or due to my rushed effort. 🙄 

But the test outlined illustrates the issue I was facing before this patch was developed.