### PR TITLE
Me mumbling about `hyperHTML`

### DIFF
--- a/test/abstracts.md
+++ b/test/abstracts.md
@@ -1,0 +1,107 @@
+# Abstract
+
+The following content represents ideal steps
+performed by hyperHTML to grant performance,
+recycle everything it can, and update layouts.
+
+It's rather a specification than current implementation,
+but the goal is to optimize such specification as much as possible
+and achieve best performance on top of that.
+
+```
+hyperHTML(statics, ...interpolations)
+│
+└▶  is `statics` known?
+    │
+    ├▶  YES
+    │
+    │   is current `context` representing `statics` ?
+    │   │
+    │   ├▶  YES
+    │   │
+    │   │   update through `interpolations`
+    │   │
+    │   └▶  NO  ┌─────────────────────────────────────────┐
+    │           ▼                                         │
+    │       clone the `fragment` related to `statics`     │
+    │                                                     │
+    │       retrieve the list of `paths` to update        │
+    │                                                     │
+    │       create a list of `updates`                    │
+    │                                                     │
+    │       relate `updates` to current `context`         │
+    │                                                     │
+    │       update `fragment` through `interpolations`    │
+    │                                                     │
+    │       replace `context` content with the `fragment` │
+    │                                                     │
+    └▶  NO                                                │
+                                                          │
+        create offline `fragment` with `statics`          │
+                                                          │
+        create a list of `paths` to update                │
+                                                          │
+        relate the `fragment` to `statics`                │
+                                                          │
+        relate the `paths` to `statics` ──────────────────┘
+```
+
+### Weakly referenced
+
+TODO: is an `expando` property that faster than a `WeakMap`?
+
+```
+context
+  ├▶  statics
+  └▶  updates
+
+any
+  └▶  wires
+```
+
+### Strongly referenced
+
+Template literals are _forever_, there's no reason to create extra GC pressure.
+
+TODO: is a native `Map` faster than a pair of arrays?
+
+```
+statics
+  ├▶  fragment
+  └▶  paths
+```
+
+### What is a wire ?
+
+A wire is a weakly linked document fragment content representing the node itself,
+as opposite of the container, like it is for `hyperHTML` bound `contexts`.
+
+```
+hyperHTML.wire(any, type:ID)
+│
+└▶  is `any` known?
+    │
+    ├▶  YES
+    │
+    │   is `:ID` already known ?
+    │   │
+    │   ├▶  YES
+    │   │
+    │   │   retrieve the `fragment` via `any`[`type:ID`]
+    │   │
+    │   │   return (...args) =>
+    │   │           hyperHTML.call(`fragment`, ...args).children;
+    │   │
+    │   └▶  NO  ┌─────────────────────────────────────────┐
+    │           ▼                                         │
+    │       create a `fragment`                           │
+    │                                                     │
+    │       relate `any`[`type:ID`] to the `fragment`     │
+    │                                                     │
+    └▶  NO                                                │
+                                                          │
+        if `any` is null, let it be a new `{}`.           │
+                                                          │
+        relate `any` to a new `{}` wire. ─────────────────┘
+```
+

--- a/test/abstracts.md
+++ b/test/abstracts.md
@@ -19,21 +19,47 @@ http://www.ecma-international.org/ecma-262/6.0/#sec-gettemplateobject
 
 Its `context` MUST be a DOM Element.
 
-`hyperHTML.bind(context)` creates a new tag for such `context`.
+`hyperHTML.bind(context)` creates a new function-tag for such `context`.
+
+```js
+const render = hyperHTML.bind(context);
+render`
+   <!-- this represents the contents of the DOM node -->
+`;
+```
 
 A list of `paths` is an array of instructions used to address a specific target node.
-Each instruction also carry the kind of update operation the target needs.
+Each instruction also includes the kind of update operation to be performed on the target node.
 
 ```js
 // paths example
 [
+  {type: 'attr', path: ['children', 1, 'attributes', 2]},
   {type: 'text', path: ['children', 1, 'childNodes', 0]},
   {type: 'any', path: ['children', 5]},
   {type: 'virtual', path: ['children', 1, 'children', 3, 'childNodes', 2]}
 ]
 ```
 
-A list of `updates` is an aray containing functions in charge of updating each path through interpolations.
+Retrieving a node through a path can be done by reducing its values.
+
+Updates are similarly defined through the following procedure.
+
+```js
+paths.forEach((info, i) => {
+  const target = info.path.reduce(
+    (node, accessor) => node[accessor],
+    fragment
+  );
+  switch (info.type) {
+    case 'attr': updates[i] = setAttribute(target); break;
+    case 'any': updates[i] = setAnyContent(target); break;
+    case 'text': updates[i] = setText(target); break;
+    case 'virtual': updates[i] = setVirtualContent(target); break;
+  }
+});
+```
+The list of `updates` is an array containing functions in charge of updating each path through interpolations.
 ```js
 // updates through interpolated values
 interpolations.forEach((value, i) => updates[i](value));

--- a/test/abstracts.md
+++ b/test/abstracts.md
@@ -8,6 +8,39 @@ It's rather a specification than current implementation,
 but the goal is to optimize such specification as much as possible
 and achieve best performance on top of that.
 
+
+
+### Definitions
+
+`hyperHTML` is a function tag for template literals.
+
+Its `statics` argument is a unique templateObject
+http://www.ecma-international.org/ecma-262/6.0/#sec-gettemplateobject
+
+Its `context` MUST be a DOM Element.
+
+`hyperHTML.bind(context)` creates a new tag for such `context`.
+
+A list of `paths` is an array of instructions used to address a specific target node.
+Each instruction also carry the kind of update operation the target needs.
+
+```js
+// paths example
+[
+  {type: 'text', path: ['children', 1, 'childNodes', 0]},
+  {type: 'any', path: ['children', 5]},
+  {type: 'virtual', path: ['children', 1, 'children', 3, 'childNodes', 2]}
+]
+```
+
+A list of `updates` is an aray containing functions in charge of updating each path through interpolations.
+```js
+// updates through interpolated values
+interpolations.forEach((value, i) => updates[i](value));
+```
+
+
+### Algorithm 
 ```
 hyperHTML(statics, ...interpolations)
 │
@@ -48,8 +81,6 @@ hyperHTML(statics, ...interpolations)
 
 ### Weakly referenced
 
-TODO: is an `expando` property that faster than a `WeakMap`?
-
 ```
 context
   ├▶  statics
@@ -63,45 +94,8 @@ any
 
 Template literals are _forever_, there's no reason to create extra GC pressure.
 
-TODO: is a native `Map` faster than a pair of arrays?
-
 ```
 statics
   ├▶  fragment
   └▶  paths
 ```
-
-### What is a wire ?
-
-A wire is a weakly linked document fragment content representing the node itself,
-as opposite of the container, like it is for `hyperHTML` bound `contexts`.
-
-```
-hyperHTML.wire(any, type:ID)
-│
-└▶  is `any` known?
-    │
-    ├▶  YES
-    │
-    │   is `:ID` already known ?
-    │   │
-    │   ├▶  YES
-    │   │
-    │   │   retrieve the `fragment` via `any`[`type:ID`]
-    │   │
-    │   │   return (...args) =>
-    │   │           hyperHTML.call(`fragment`, ...args).children;
-    │   │
-    │   └▶  NO  ┌─────────────────────────────────────────┐
-    │           ▼                                         │
-    │       create a `fragment`                           │
-    │                                                     │
-    │       relate `any`[`type:ID`] to the `fragment`     │
-    │                                                     │
-    └▶  NO                                                │
-                                                          │
-        if `any` is null, let it be a new `{}`.           │
-                                                          │
-        relate `any` to a new `{}` wire. ─────────────────┘
-```
-


### PR DESCRIPTION
The `hyperHTML.adopt` is already a branch but it opened my mind about splitting up common steps within the code.

I am creating a sort of abstract specification to follow up during a massive refactoring I am doing on my local machine.

This file is not official, not final, and most likely not accurate too **but** it's helping me figure out all the needed steps to make this refactoring happening, obtaining best possible performance.