### PR TITLE
TypeScript. Fixed ShadowRoot types in the bind function

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 type TemplateFunction<T> = (template: TemplateStringsArray, ...values: any[]) => T;
-export type BoundTemplateFunction<T extends Element> = TemplateFunction<T>;
+export type BoundTemplateFunction<T extends Element | ShadowRoot> = TemplateFunction<T>;
 export type WiredTemplateFunction = TemplateFunction<any>;
 
 export declare class Component<T = {}> {
@@ -12,7 +12,7 @@ export declare class Component<T = {}> {
   setState(state: Partial<T> | ((this: this, state: T) => Partial<T>), render?: boolean): this;
 }
 
-export declare function bind<T extends Element>(element: T): BoundTemplateFunction<T>;
+export declare function bind<T extends Element | ShadowRoot>(element: T): BoundTemplateFunction<T>;
 
 export declare function define(intent: string, callback: Function): void;
 


### PR DESCRIPTION
This PR addresses to fix the error:
`          TS2345: Argument of type 'ShadowRoot' is not assignable to parameter of type 'Element'.
      Property 'classList' is missing in type 'ShadowRoot'.`

It's happen when we try to send a ShadowRoot to the bind function:
```typescript
      const shadowRoot = this.attachShadow({ mode });
      this.html = hyperHTML.bind(shadowRoot);
```