### PR TITLE
Adds space check in attrPartials regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ var hyperHTML = (function (global) {
   var almostEverything = '[^ ' + spaces + '\\/>"\'=]+';
   var attrName = '[ ' + spaces + ']+' + almostEverything;
   var tagName = '<([A-Za-z]+[A-Za-z0-9:_-]*)((?:';
-  var attrPartials = '(?:=(?:\'[^\']*?\'|"[^"]*?"|<[^>]*?>|' + almostEverything + '))?)';
+  var attrPartials = '(?:[' + spaces + ']*=[' + spaces + ']*(?:\'[^\']*?\'|"[^"]*?"|<[^>]*?>|' + almostEverything + '))?)';
 
   var attrSeeker = new RegExp(tagName + attrName + attrPartials + '+)([ ' + spaces + ']*/?>)', 'g');
 


### PR DESCRIPTION
For html attributes with space around the equal sign hyperHTML throws an error

> Uncaught TypeError: this[(i - 1)] is not a function

```
function show(render, state) {
    render`
      <div id ="d1" class = "panel" style=${state}>
        some other text
      </div>
    `;
  }

  show(hyperHTML.bind(document.body), {background: 'lightblue'});
```

There are use-cases where 
- html templates are fetched from server 
- developer prefer spacing for readability

For these cases the app crashes.

The fix checks for spaces before and after equal sign of `id ="d1"`, `class = "panel"`