### PR TITLE
lightercollective switched to optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
       "uglify-js"
     ]
   },
-  "dependencies": {
+  "optionalDependencies": {
     "lightercollective": "^0.1.0"
   },
   "collective": {


### PR DESCRIPTION
While I'm a big fan and _do_ currently support on patreon - it seems a bit over the top to force the installation of the opencollective / lightercollective package (now much smaller but that's not really the point).

This change will allow people to pass the `--no-optional` flag when installing to prevent optionals from being installed.

_side note: lightercollective feature doesn't work with yarn._