### PR TITLE
Support CSS custom properties in style object

### DIFF
--- a/cjs/objects/Style.js
+++ b/cjs/objects/Style.js
@@ -40,9 +40,11 @@ const update = (style, isSVG) => {
           const info = isSVG ? {} : style;
           for (const key in newValue) {
             const value = newValue[key];
-            info[key] = typeof value === 'number' &&
+            const styleValue = typeof value === 'number' &&
                         !IS_NON_DIMENSIONAL.test(key) ?
                           (value + 'px') : value;
+            if (key.indexOf('--') === 0) info.setProperty(key, styleValue);
+            else info[key] = styleValue;
           }
           oldType = 'object';
           if (isSVG) style.value = toStyle((oldValue = info));

--- a/esm/objects/Style.js
+++ b/esm/objects/Style.js
@@ -39,9 +39,11 @@ const update = (style, isSVG) => {
           const info = isSVG ? {} : style;
           for (const key in newValue) {
             const value = newValue[key];
-            info[key] = typeof value === 'number' &&
+            const styleValue = typeof value === 'number' &&
                         !IS_NON_DIMENSIONAL.test(key) ?
                           (value + 'px') : value;
+            if (key.indexOf('--') === 0) info.setProperty(key, styleValue);
+            else info[key] = styleValue;                      
           }
           oldType = 'object';
           if (isSVG) style.value = toStyle((oldValue = info));

--- a/index.js
+++ b/index.js
@@ -623,7 +623,9 @@ var hyperHTML = (function (global) {
             var info = isSVG ? {} : style;
             for (var _key in newValue) {
               var value = newValue[_key];
-              info[_key] = typeof value === 'number' && !IS_NON_DIMENSIONAL.test(_key) ? value + 'px' : value;
+              var styleValue = typeof value === 'number' && !IS_NON_DIMENSIONAL.test(_key) ? value + 'px' : value;
+              if (_key.indexOf('--') === 0) info.setProperty(_key, styleValue);
+              else info[_key] = styleValue;
             }
             oldType = 'object';
             if (isSVG) style.value = toStyle(oldValue = info);else oldValue = newValue;

--- a/test/test.js
+++ b/test/test.js
@@ -996,6 +996,8 @@ tressa.async(function (done) {
   tressa.assert(!node.style.fontSize, 'object cleaned');
   p('font-size: 18px');
   tressa.assert(node.style.fontSize, node.style.fontSize);
+  // p({ '--primary': 'red' });
+  // tressa.assert(node.style.getPropertyValue('--primary') === 'red', 'custom property ok');
 })
 .then(function () {
   tressa.log('## <self-closing />');


### PR DESCRIPTION
Here I am again, hopefully not wasting your time again.

This PR should allow usage of CSS custom properties when the style is passed as object. Currently it works only if passed as string. [Codepen](https://codepen.io/jiayihu/pen/eLevoP?editors=0011).

Unfortunately the new test case I'm trying to add doesn't work because `setProperty` and `getPropertyValue` are missing in `CSSStyleDeclaration`. I'm not familiar with the test system used here, although I think jsdom is used and maybe it's related to https://github.com/jsdom/jsdom/issues/1895 . 

Also not sure if repeating the same code in `index.js`, `esm/` and `cjs/` is correct. At a quick look of past commits and `package.json`, none of the three seem to be generated automatically.

TLDR; the fix should be quick, but there are problems with the build system which I'm not familiar to. If it's quicker for you, I'm fine with closing the PR and leave it to you rather than explaining the details of how build/tests are set up in the repo.
