### PR TITLE
Added missing dispatch() method to the hyper.Component type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ export declare class Component<T = {}> {
   state: T;
   readonly defaultState: T;
   setState(state: Partial<T> | ((this: this, state: T) => Partial<T>), render?: boolean): this;
+  dispatch(type: string, detail?: any): boolean;
 }
 
 export declare function bind<T extends Element | ShadowRoot>(element: T): BoundTemplateFunction<T>;


### PR DESCRIPTION
Somehow the relatively new but very useful `dispatch()` method was left out in TypeScript type definitions file. This should fix it.