### PR TITLE
ci: test Node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - stable
+  - 10
 git:
   depth: 1
 branches:


### PR DESCRIPTION
`stable` tests current stable wich is 11 not 10.
Let's check 10 too.

Should we also test the other LTS branches like 8 and 6?