### PR TITLE
Readme: fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Please ask anything you'd like to know in [StackOverflow](https://stackoverflow.
 
 #### hyper or lit ?
 
-You can read more on this [hyperHTML vs lit-html](https://gist.github.com/WebReflection/fadcc419f5ccaae92bc167d8ff5c611b) comparison.
+You can read more on this [hyperHTML vs lit-html](https://medium.com/@WebReflection/lit-html-vs-hyperhtml-vs-lighterhtml-c084abfe1285) comparison.
 
 #### installation?
 


### PR DESCRIPTION
The [current link](https://gist.github.com/WebReflection/fadcc419f5ccaae92bc167d8ff5c611b) on the README is broken, I believe that we can replace it with [this one](https://medium.com/@WebReflection/lit-html-vs-hyperhtml-vs-lighterhtml-c084abfe1285)