### PR TITLE
Fix HELPERS.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can require or import _hyperHTML_ with any bundler and in different ways.
 
 If requiring or importing from `"hyperhtml"` doesn't work, try requiring from `"hyperhtml/cjs"` for CommonJS friendly bundlers (WebPack), or `"hyperhtml/esm"` for ESM compatible bundlers (Rollup).
 
-See [HELPERS.md] for a list of additional tools which can be helpful for building hyperHTML based web applications.
+See [HELPERS.md](./HELPERS.md) for a list of additional tools which can be helpful for building hyperHTML based web applications.
 
 - - -
 


### PR DESCRIPTION
I thought that `[HELPERS.md]` would give an auto-link to a repository file, I was wrong.  Sorry for missing this.