### PR TITLE
defaultState is now declared as a getter in the declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export declare class Component<T = {}> {
   html: WiredTemplateFunction;
   svg: WiredTemplateFunction;
   state: T;
-  readonly defaultState: T;
+  get defaultState(): T;
   setState(state: Partial<T> | ((this: this, state: T) => Partial<T>), render?: boolean): this;
   dispatch(type: string, detail?: any): boolean;
 }
@@ -32,7 +32,7 @@ export declare const hyper: {
 
   // hyper('html')`HTML`
   (type: 'html' | 'svg'): WiredTemplateFunction;
-  
+
   // hyper(element)`HTML`
   <T extends Element>(element: T): BoundTemplateFunction<T>;
 


### PR DESCRIPTION
This is a tiny change to the .d.ts file that solves the issue [described here](https://github.com/WebReflection/hyperHTML/pull/201#issuecomment-368089142) with `defaultState` not being declared exactly the same way it was implemented and upsetting the type checker when e.g. overridden in a class derived from the `Component`.

get/set declarations in `d.ts` files should be [supported since 3.6 release](https://devblogs.microsoft.com/typescript/announcing-typescript-3-6/#get-and-set-accessors-allowed-in-ambient-contexts) of TypeScript, which was 3 years ago. So, while in theory someone using hyperHTML with an older TS version is most likely to get unexpected type checking errors because of this change, but in practice there wouldn't be many people like this, I assume. I don't quite know what's your policy regarding breaking changes in the type declarations file, but now you know about it's potential effect. 

Maybe TS compatibility warrants a note in the Readme somewhere, what do you think?