### PR TITLE
Added return type inference for the Component.for() utility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ export type BoundTemplateFunction<T extends Element | ShadowRoot> = TemplateFunc
 export type WiredTemplateFunction = TemplateFunction<any>;
 
 export declare class Component<T = {}> {
-  static for(context: object, identity?: any): Component;
+  static for<TComponent>(this: new() => TComponent, context: object, identity?: any): TComponent;
   handleEvent(e: Event): void;
   html: WiredTemplateFunction;
   svg: WiredTemplateFunction;


### PR DESCRIPTION
With this micro-change the return type for a code like `MyButton.for(whatever)` should be correctly inferred to be `MyButton` instead of the more general `Component` .